### PR TITLE
Use edit tags instead of edit summaries to detect reverts

### DIFF
--- a/config/config.no-mk.yml
+++ b/config/config.no-mk.yml
@@ -17,8 +17,8 @@ othersites:
     - kn.wikipedia.org
     - syl.wikipedia.org
 contestPages:
-    resultsSection: 'Resultater|Results'
-    participantsSection: 'Delta[kg]ere|Participants'
+    resultsSection: 'Resultater'
+    participantsSection: 'Delta[kg]ere'
     footer: "{{Månedens konkurranse %(year)s}}\n[[Kategori:Artikkelkonkurranser]]"
 templates:
     contestlist:

--- a/config/sites/cawiki.yml
+++ b/config/sites/cawiki.yml
@@ -1,7 +1,5 @@
 _extends: default.yml
-locale: [ca_ES, ca_AD, ca_FR, ca_IT, ca_ES@valencia]
-server_timezone: UTC
-wiki_timezone: Europe/Andorra
+wiki_timezone: Europe/Berlin
 homesite: ca.wikipedia.org
 othersites:
     - ca.wikiquote.org

--- a/config/sites/cawiki.yml
+++ b/config/sites/cawiki.yml
@@ -1,5 +1,5 @@
+_extends: default.yml
 locale: [ca_ES, ca_AD, ca_FR, ca_IT, ca_ES@valencia]
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: Europe/Andorra
 homesite: ca.wikipedia.org
@@ -121,14 +121,3 @@ awardstatus:
     wait: Esperant
     send: Envia
     sent: Enviat
-ignore:
-    - Tilbakestilte endring # MediaWiki:Revertpage/nb
-    - Attenderulla endring  # MediaWiki:Revertpage/nn
-    - rievdadusat sihkkojuvvui ja siidu  # MediaWiki:Revertpage/se
-    - Reverted edits by  # MediaWiki:Revertpage/en
-    - Fjerner revisjon # MediaWiki:Undo-summary/nb
-    - Rullar attende versjon # MediaWiki:Undo-summary/nn
-    - Undo revision # MediaWiki:Revertpage/en
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink
-    - Revertides les edicions # MediaWiki:Revertpage/ca

--- a/config/sites/default.yml
+++ b/config/sites/default.yml
@@ -1,0 +1,26 @@
+server_timezone: UTC
+wiki_timezone: UTC
+ignoreTags:
+    - mw-reverted # Edits that have been reverted
+    - mw-manual-revert # Edits that manually revert to a previous version
+    - mw-undo # Edits that undo other edits
+    - mw-rollback # Edits made using the "rollback" button
+    # Wikidata-specific
+    - client-linkitem-change # Add/change interwiki links
+    - client-automatic-update # Moving pages
+    - 'OAuth CID: 1776' # QuickStatements 2.0
+    - 'OAuth CID: 1351' # QuickStatements 1.5
+    - 'OAuth CID: 1253' # QuickStatements 1.3
+    - 'OAuth CID: 699' # QuickStatements 1.1
+    - 'OAuth CID: 9364' # QuickStatements 3.0
+    - openrefine
+    - openrefine-3.0
+    - openrefine-3.1
+    - openrefine-3.2
+    - openrefine-3.3
+    - openrefine-3.4
+    - openrefine-3.5
+    - openrefine-3.6
+    - openrefine-3.7
+    - openrefine-3.8
+    - openrefine-4.0

--- a/config/sites/enwiki.yml
+++ b/config/sites/enwiki.yml
@@ -1,7 +1,4 @@
 _extends: default.yml
-locale: [en_US]
-server_timezone: UTC
-wiki_timezone: Europe/Oslo
 homesite: en.wikipedia.org
 default_prefix: en
 wikidata_languages: ['en']

--- a/config/sites/enwiki.yml
+++ b/config/sites/enwiki.yml
@@ -1,5 +1,5 @@
+_extends: default.yml
 locale: [en_US]
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: Europe/Oslo
 homesite: en.wikipedia.org
@@ -119,13 +119,3 @@ awardstatus:
     wait: Venter
     send: Send ut
     sent: Sendt
-ignore:
-    - Tilbakestilte endring # MediaWiki:Revertpage/nb
-    - Attenderulla endring  # MediaWiki:Revertpage/nn
-    - rievdadusat sihkkojuvvui ja siidu  # MediaWiki:Revertpage/se
-    - Reverted edits by  # MediaWiki:Revertpage/en
-    - Fjerner revisjon # MediaWiki:Undo-summary/nb
-    - Rullar attende versjon # MediaWiki:Undo-summary/nn
-    - Undo revision # MediaWiki:Revertpage/en
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink

--- a/config/sites/eswiki.yml
+++ b/config/sites/eswiki.yml
@@ -1,5 +1,5 @@
+_extends: default.yml
 locale: [es_ES,en_US]
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: UTC
 homesite: es.wikipedia.org
@@ -96,9 +96,3 @@ templates:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
-ignore:
-    - Revertida una edición # MediaWiki:Revertpage/es
-    - 'Revertidas \d+ ediciones' # MediaWiki:Revertpage/es
-    - Deshecha la # MediaWiki:Undo-summary/es
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink

--- a/config/sites/eswiki.yml
+++ b/config/sites/eswiki.yml
@@ -1,7 +1,4 @@
 _extends: default.yml
-locale: [es_ES,en_US]
-server_timezone: UTC
-wiki_timezone: UTC
 homesite: es.wikipedia.org
 default_prefix: es
 wikidata_languages: ['es', 'en']

--- a/config/sites/euwiki.yml
+++ b/config/sites/euwiki.yml
@@ -1,5 +1,5 @@
+_extends: default.yml
 locale: [eu_ES,en_US]
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: Europe/Oslo
 homesite: eu.wikipedia.org
@@ -98,13 +98,3 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
-ignore:
-    - Tilbakestilte endring # MediaWiki:Revertpage/nb
-    - Attenderulla endring  # MediaWiki:Revertpage/nn
-    - rievdadusat sihkkojuvvui ja siidu  # MediaWiki:Revertpage/se
-    - Reverted edits by  # MediaWiki:Revertpage/en
-    - Fjerner revisjon # MediaWiki:Undo-summary/nb
-    - Rullar attende versjon # MediaWiki:Undo-summary/nn
-    - Undo revision # MediaWiki:Revertpage/en
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink

--- a/config/sites/euwiki.yml
+++ b/config/sites/euwiki.yml
@@ -1,7 +1,5 @@
 _extends: default.yml
-locale: [eu_ES,en_US]
-server_timezone: UTC
-wiki_timezone: Europe/Oslo
+wiki_timezone: Europe/Berlin
 homesite: eu.wikipedia.org
 othersites:
     - eu.wikibooks.org

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -1,5 +1,5 @@
+_extends: default.yml
 locale: fi_FI
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: Europe/Helsinki
 homesite: fi.wikipedia.org
@@ -99,9 +99,13 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
+<<<<<<< HEAD
 ignore:
     - muokkaukset kumottiin ja sivu palautettiin # MediaWiki:Revertpage
     - ^Hylättiin (viimeisin tekstimuutos|viimeisimmät .* tekstimuutosta) # MediaWiki:Revreview-reject-summary-cur/fi
     - ^Kumottu muokkaus # MediaWiki:Undo-summary/fi
     - clientsitelink-update  # Wikidata: Page moved from .. to ..
     - clientsitelink-remove  # Wikidata: Removed sitelink
+=======
+    columns: Sarakkeet
+>>>>>>> e74fcf3 (Use edit tags instead of edit summaries to detect reverts)

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -99,13 +99,3 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
-<<<<<<< HEAD
-ignore:
-    - muokkaukset kumottiin ja sivu palautettiin # MediaWiki:Revertpage
-    - ^Hylättiin (viimeisin tekstimuutos|viimeisimmät .* tekstimuutosta) # MediaWiki:Revreview-reject-summary-cur/fi
-    - ^Kumottu muokkaus # MediaWiki:Undo-summary/fi
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink
-=======
-    columns: Sarakkeet
->>>>>>> e74fcf3 (Use edit tags instead of edit summaries to detect reverts)

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -1,6 +1,4 @@
 _extends: default.yml
-locale: fi_FI
-server_timezone: UTC
 wiki_timezone: Europe/Helsinki
 homesite: fi.wikipedia.org
 default_prefix: fi

--- a/config/sites/glwiki.yml
+++ b/config/sites/glwiki.yml
@@ -1,7 +1,4 @@
 _extends: default.yml
-locale: [gl_ES,en_US]
-server_timezone: UTC
-wiki_timezone: UTC
 homesite: gl.wikipedia.org
 default_prefix: gl
 wikidata_languages: ['gl', 'en']

--- a/config/sites/glwiki.yml
+++ b/config/sites/glwiki.yml
@@ -1,3 +1,4 @@
+_extends: default.yml
 locale: [gl_ES,en_US]
 server_timezone: UTC
 wiki_timezone: UTC
@@ -95,9 +96,3 @@ templates:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
-ignore:
-    - Revertida unha edición # MediaWiki:Revertpage/es
-    - 'Revertidas \d+ edicións' # MediaWiki:Revertpage/es
-    - Desfeita a # MediaWiki:Undo-summary/es
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink

--- a/config/sites/nowiki.yml
+++ b/config/sites/nowiki.yml
@@ -1,7 +1,5 @@
 _extends: default.yml
-locale: [nb_NO, no_NO]
-server_timezone: UTC
-wiki_timezone: Europe/Oslo
+wiki_timezone: Europe/Berlin
 homesite: no.wikipedia.org
 othersites:
     - nn.wikipedia.org

--- a/config/sites/nowiki.yml
+++ b/config/sites/nowiki.yml
@@ -1,6 +1,5 @@
----
+_extends: default.yml
 locale: [nb_NO, no_NO]
-rollbar_token: 88f5bd483f7348ea8b0564449c8d77cd
 server_timezone: UTC
 wiki_timezone: Europe/Oslo
 homesite: no.wikipedia.org
@@ -122,17 +121,3 @@ awardstatus:
     wait: Venter
     send: Send ut
     sent: Sendt
-ignore:
-    - Tilbakestilte endring # MediaWiki:Revertpage/nb
-    - Attenderulla endring  # MediaWiki:Revertpage/nn
-    - rievdadusat sihkkojuvvui ja siidu  # MediaWiki:Revertpage/se
-    - muokkaukset kumottiin ja sivu palautettiin # MediaWiki:Revertpage/fi (not translated into smn yet)
-    - Reverted edits by  # MediaWiki:Revertpage/en
-    - Fjerner revisjon # MediaWiki:Undo-summary/nb
-    - Rullar attende versjon # MediaWiki:Undo-summary/nn
-    - ^Kumottu muokkaus # MediaWiki:Undo-summary/fi (not translated into smn yet)
-    - Undo revision # MediaWiki:Revertpage/en
-    - clientsitelink-update  # Wikidata: Page moved from .. to ..
-    - clientsitelink-remove  # Wikidata: Removed sitelink
-    - '#temporary_batch'  # QuickStatements Author Disambiguator o.l.
-    - '#quickstatements'  # QuickStatements

--- a/ukbot/site.py
+++ b/ukbot/site.py
@@ -60,12 +60,6 @@ class Site(mwclient.Site):
     def __hash__(self):
         return hash(self.__repr__())
 
-    def get_revertpage_regexp(self):
-        msg = self.pages['MediaWiki:Revertpage'].text()
-        msg = re.sub(r'\[\[[^\]]+\]\]', '.*?', msg)
-        msg = re.sub(r'(?i)\{\{PLURAL:\$\d\|(.+)\}\}', '(\1)', msg)
-        return msg
-
     def match_prefix(self, prefix):
         return prefix in self.prefixes or prefix == self.key
 

--- a/ukbot/sites.py
+++ b/ukbot/sites.py
@@ -87,8 +87,8 @@ class SiteManager(object):
 
 def init_sites(config):
 
-    if 'ignore' not in config:
-        config['ignore'] = []
+    if 'ignoreTags' not in config:
+        config['ignoreTags'] = []
 
     # Configure home site (where the contests live)
     host = config['homesite']
@@ -109,11 +109,5 @@ def init_sites(config):
         for host in config['othersites']:
             prefixes = [k for k, v in iwmap.items() if v == host]
             sites[host] = Site(host, prefixes=prefixes)
-
-    for site in sites.values():
-        msg = site.get_revertpage_regexp()
-        if msg != '':
-            logger.debug('Revert page regexp: %s', msg)
-            config['ignore'].append(msg)
 
     return SiteManager(sites, homesite), sql

--- a/ukbot/util.py
+++ b/ukbot/util.py
@@ -68,20 +68,25 @@ def merge(base, current):
 
 def load_config(fp):
     folder = os.path.split(fp.name)[0]
+    logger.info('Loading config %s', fp.name)
+
+    config = {}
+    base_config = {}
 
     main_config = yaml.safe_load(fp)
     if '_extends' in main_config:
         filename = os.path.join(folder, main_config['_extends'])
         with open(filename, encoding='utf-8') as fp2:
-            base_config = yaml.safe_load(fp2)
-    else:
-        base_config = {}
+            base_config = load_config(fp2)
 
     config = merge(base_config, main_config)
 
-    config['wiki_timezone'] = pytz.timezone(config['wiki_timezone'])
-    config['server_timezone'] = pytz.timezone(config['server_timezone'])
+    if isinstance(config.get('wiki_timezone'), str):
+        config['wiki_timezone'] = pytz.timezone(config['wiki_timezone'])
+    if isinstance(config.get('server_timezone'), str):
+        config['server_timezone'] = pytz.timezone(config['server_timezone'])
 
+    logger.debug('Config: %s', config)
     return config
 
 


### PR DESCRIPTION
Use edit tags to detect reverts and other types of edits that should be ignored for contests. This involves a refactoring of the config files to also include one common default.yml config file, which can be overridden if needed. This default file includes the tags that we normally don't want to care about; including tags for revert edits, reverted edits, undo edits, and various automated Wikidata edits (most notably QuickStatements).

This fixes #45.