### PR TITLE
refactor: Enhance error handling in contest filters to log non-fatal warnings for missing categories and unrecognized wikis

### DIFF
--- a/ukbot/contest.py
+++ b/ukbot/contest.py
@@ -224,14 +224,31 @@ class Contest(object):
                 try:
                     filter_inst = filter_tpl.make(self)
                 except RuntimeError as exp:
-                    raise InvalidContestPage(
-                        _('Could not parse {{tlx|%(template)s|%(firstarg)s}} template: %(err)s')
-                        % {
-                            'template': filter_template_config['name'],
-                            'firstarg': filter_tpl.anon_params[1],
-                            'err': str(exp)
-                        }
-                    )
+                    # Only abort for truly fatal errors (like missing required arguments)
+                    fatal_errors = [
+                        'Too few arguments',
+                        'No category values given',
+                        'No byte limit',
+                        'No "%s" parameter given',
+                        'Could not parse the catignore page',
+                    ]
+                    msg = str(exp)
+                    if any(fe in msg for fe in fatal_errors):
+                        raise InvalidContestPage(
+                            _('Could not parse {{tlx|%(template)s|%(firstarg)s}} template: %(err)s')
+                            % {
+                                'template': filter_template_config['name'],
+                                'firstarg': filter_tpl.anon_params[1],
+                                'err': msg
+                            }
+                        )
+                    # Otherwise, treat as warning and continue
+                    logger.warning('Non-fatal filter error: %s', msg)
+                    try:
+                        self.sites.homesite.errors.append(_('Warning: %(msg)s') % {'msg': msg})
+                    except Exception as e:
+                        logger.warning('Could not attach warning to homesite: %s', e)
+                    continue
 
                 nfilters += 1
                 if op == 'OR':


### PR DESCRIPTION
## Description
This PR adds enhanced error handling in contest filters, logging non-fatal warnings for missing categories and unrecognized wikis.

It has been tested, but there may still be edge cases I haven’t considered.

It will show in console like this:
![Screenshot 2025-05-24 at 21 29 08](https://github.com/user-attachments/assets/e82dcc52-8c54-4db4-a526-c1b91eb19379)[[1](https://no.wikipedia.org/w/index.php?title=Bruker:Premeditated/Sandkasse5&oldid=25155496)]

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #62

## Tested?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📖 own file under the docs folder
- [X] 🙅 no documentation needed

## [optional] Are there any pre- or post-deployment tasks we need to perform?
No