### PR TITLE
Returned Elokuun kuvitustalkoot config back to "fi-ek" from "fi-ek202…

### DIFF
--- a/jobs.yaml
+++ b/jobs.yaml
@@ -73,18 +73,18 @@
   schedule: "45 22 * * *"
   emails: onfailure
 # fi-ek
-- name: fi-ek2023
-  command: ./jobs/run.sh fi-ek2023
+- name: fi-ek
+  command: ./jobs/run.sh fi-ek
   image: python3.11
   schedule: "29 * * * *"
   emails: onfailure
   mem: 2Gi
-- name: upload-plot-fi-ek2023
-  command: ./jobs/upload.sh fi-ek2023
+- name: upload-plot-fi-ek
+  command: ./jobs/upload.sh fi-ek
   image: python3.11
   schedule: "50 22 * * *"
   emails: onfailure
-# fi-ek
+# fi-wsc
 - name: fi-wsc
   command: ./jobs/run.sh fi-wsc
   image: python3.11


### PR DESCRIPTION
…3" in jobs.yaml

## Description

There was a custom Elokuun kuvitustalkoot config in 2023, probably because of incorrect competition settings, and it was worked around by using a different competition ID. However, since it only worked in 2023, I have now reverted the jobs.yaml back to the multiyear config.

NOTE: This is also updated now directly to production as the competition is already started.