### PR TITLE
add webp and xcf suffix to rules/image.py regexp

### DIFF
--- a/ukbot/rules/image.py
+++ b/ukbot/rules/image.py
@@ -37,7 +37,7 @@ class ImageRule(Rule):
 
         # Compile regexps for match images
         prefixes = r'(?:%s)' % '|'.join(['%s:' % x for x in self.file_prefixes])
-        suffixes = r'\.(?:svg|png|jpe?g|gif|tiff)'
+        suffixes = r'\.(?:svg|png|jpe?g|gif|tiff|webp|xcf)'
         imagematcher = r"""
             (?:
                 (?:=|\||^)%(prefixes)s?   # "=File:", "=", "|File:", "|", ...


### PR DESCRIPTION
Note: I did the change already directly to production to test it so it needs to be reverted from ukbot/rules/image.py before pulling it.